### PR TITLE
Handler list and event context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cassava",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassava",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "AWS API Gateway Router",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/ProxyEvent.ts
+++ b/src/ProxyEvent.ts
@@ -2,6 +2,7 @@
  * API Gateway proxy object.
  * see: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html#api-gateway-simple-proxy-for-lambda-input-format
  */
+
 export interface ProxyEvent {
 
     /**
@@ -56,20 +57,27 @@ export interface ProxyEvent {
         accountId: string,
         apiId: string,
         httpMethod: string,
+        authorizer?: {
+            [name: string]: any,
+        },
         identity: {
             accessKey: string,
             apiKey: string,
             accountId: string,
+            apiKeyId: string,
             caller: string,
             cognitoAuthenticationProvider: string,
             cognitoAuthenticationType: string,
+            cognitoIdentityId: string,
             cognitoIdentityPoolId: string,
             sourceIp: string,
             user: string,
             userAgent: string,
             userArn: string
         },
+        path: string,
         requestId: string,
+        requestTimeEpoch: number,
         resourceId: string,
         resourcePath: string,
         stage: string

--- a/src/ProxyEvent.ts
+++ b/src/ProxyEvent.ts
@@ -53,13 +53,11 @@ export interface ProxyEvent {
     /**
      * API Gateway event context.
      */
-    context: {
+    requestContext: {
         accountId: string,
         apiId: string,
+        authorizer?: { [name: string]: any },
         httpMethod: string,
-        authorizer?: {
-            [name: string]: any,
-        },
         identity: {
             accessKey: string,
             apiKey: string,

--- a/src/Router.test.ts
+++ b/src/Router.test.ts
@@ -164,7 +164,7 @@ describe("Router", () => {
                         body: {
                             drum: "bass"
                         }
-                    }
+                    };
                 });
 
             const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -219,7 +219,7 @@ describe("Router", () => {
                         body: {
                             hip: "hop"
                         }
-                    }
+                    };
                 });
 
             const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -384,7 +384,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async evt => {
-                        throw new cassava.RestError(400, "This is my custom error message")
+                        throw new cassava.RestError(400, "This is my custom error message");
                     });
 
                 const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -404,7 +404,7 @@ describe("Router", () => {
                 router.route({
                     matches: () => true,
                     postProcess: () => {
-                        throw new RestError(418, "I'm a teapot.")
+                        throw new RestError(418, "I'm a teapot.");
                     }
                 });
 
@@ -428,7 +428,7 @@ describe("Router", () => {
                 router.defaultRoute = {
                     matches: () => true,
                     handle: () => {
-                        throw new RestError(403, "You have 15 seconds to comply.")
+                        throw new RestError(403, "You have 15 seconds to comply.");
                     }
                 };
 
@@ -448,7 +448,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async evt => {
-                        throw new cassava.RestError(400, "This is my custom error message")
+                        throw new cassava.RestError(400, "This is my custom error message");
                     });
 
                 let errorHandlerCalled = false;
@@ -459,7 +459,7 @@ describe("Router", () => {
                         body: {
                             fruit: "loops"
                         }
-                    }
+                    };
                 };
 
                 const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -484,7 +484,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async evt => {
-                        throw new cassava.RestError(400, "This is my custom error message")
+                        throw new cassava.RestError(400, "This is my custom error message");
                     });
 
                 const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -501,7 +501,7 @@ describe("Router", () => {
 
                     router.route("/foo")
                         .handler(async evt => {
-                            throw new cassava.RestError(400, "This is my custom error message", {a: "alpha", b: "beta"})
+                            throw new cassava.RestError(400, "This is my custom error message", {a: "alpha", b: "beta"});
                         });
 
                     const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -525,7 +525,7 @@ describe("Router", () => {
                             throw new cassava.RestError(400, "This is my custom error message", {
                                 statusCode: 123,
                                 message: "pretty sneaky, sis"
-                            })
+                            });
                         });
 
                     const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -544,7 +544,7 @@ describe("Router", () => {
 
                     router.route("/foo")
                         .handler(async evt => {
-                            throw new cassava.RestError(400, "This is my custom error message", {})
+                            throw new cassava.RestError(400, "This is my custom error message", {});
                         });
 
                     const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -564,7 +564,7 @@ describe("Router", () => {
 
                         router.route("/foo")
                             .handler(async evt => {
-                                throw new cassava.RestError(400, "This is my custom error message", value as any)
+                                throw new cassava.RestError(400, "This is my custom error message", value as any);
                             });
 
                         const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -588,7 +588,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async () => {
-                        throw new Error("This error message should not be leaked")
+                        throw new Error("This error message should not be leaked");
                     });
 
                 const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -609,7 +609,7 @@ describe("Router", () => {
                 router.route({
                     matches: () => true,
                     postProcess: () => {
-                        throw new Error("I'm the world's angriest teapot and I will kill your whole family.")
+                        throw new Error("I'm the world's angriest teapot and I will kill your whole family.");
                     }
                 });
 
@@ -634,7 +634,7 @@ describe("Router", () => {
                 router.defaultRoute = {
                     matches: () => true,
                     handle: () => {
-                        throw new Error("I apologize for the previous teapot.")
+                        throw new Error("I apologize for the previous teapot.");
                     }
                 };
 
@@ -664,7 +664,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async evt => {
-                        throw new Error("All teapots report for sensitivity training.")
+                        throw new Error("All teapots report for sensitivity training.");
                     });
 
                 const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -682,7 +682,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async () => {
-                        throw new Error("Everything was beautiful and nothing hurt.")
+                        throw new Error("Everything was beautiful and nothing hurt.");
                     });
 
                 let errorHandlerCalled = false;
@@ -704,7 +704,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async () => {
-                        throw new Error("Everything was beautiful and nothing hurt.")
+                        throw new Error("Everything was beautiful and nothing hurt.");
                     });
 
                 let errorHandlerCalled = false;
@@ -719,7 +719,7 @@ describe("Router", () => {
                         body: {
                             errMessage: err.message
                         }
-                    }
+                    };
                 };
 
                 const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -738,7 +738,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async () => {
-                        throw new Error("So it goes.")
+                        throw new Error("So it goes.");
                     });
 
                 let errorHandlerCalled = false;
@@ -749,7 +749,7 @@ describe("Router", () => {
                         body: {
                             errMessage: err.message
                         }
-                    }
+                    };
                 };
 
                 const resp = await testRouter(router, createTestProxyEvent("/foo"));
@@ -769,7 +769,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async () => {
-                        throw new Error("This error message should not be leaked")
+                        throw new Error("This error message should not be leaked");
                     });
 
                 let errorHandlerCalled = false;
@@ -795,7 +795,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async () => {
-                        throw new Error("This error message should not be leaked")
+                        throw new Error("This error message should not be leaked");
                     });
 
                 let errorHandlerCalled = false;
@@ -822,7 +822,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async () => {
-                        throw new Error("This error message should not be leaked")
+                        throw new Error("This error message should not be leaked");
                     });
 
                 let errorHandlerCalled = false;
@@ -848,7 +848,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async () => {
-                        throw new Error("This error message should not be leaked")
+                        throw new Error("This error message should not be leaked");
                     });
 
                 let errorHandlerCalled = false;
@@ -890,7 +890,7 @@ describe("Router", () => {
 
                 router.route("/foo")
                     .handler(async evt => {
-                        throw new Error("All teapots report for sensitivity training.")
+                        throw new Error("All teapots report for sensitivity training.");
                     });
 
                 const resp = await testRouter(router, createTestProxyEvent("/foo"));

--- a/src/Router.test.ts
+++ b/src/Router.test.ts
@@ -110,6 +110,22 @@ describe("Router", () => {
             chai.assert.isObject(resp);
             chai.assert.equal(resp.statusCode, 500, JSON.stringify(resp));
         });
+
+        it("returns defaultRoute in handlers array if no other routes handle event", async () => {
+            const router = new cassava.Router();
+
+            router.route(/.*/)
+                .postProcessor(async (evt, resp, handlers) => {
+                    chai.assert.lengthOf(handlers, 1);
+                    chai.assert.deepEqual(handlers[0], router.defaultRoute);
+                    return resp;
+                });
+
+            const resp = await testRouter(router, createTestProxyEvent("/path/less/taken"));
+
+            chai.assert.isObject(resp);
+            chai.assert.equal(resp.statusCode, 404, JSON.stringify(resp));
+        });
     });
 
     it("returns a response when useLegacyCallbackHandler = true", async () => {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -129,6 +129,7 @@ export class Router {
                 if (!this.defaultRoute.handle) {
                     throw new Error("Router's defaultRoute.handle is not defined.");
                 }
+                handlingRoute = this.defaultRoute;
                 resp = await this.defaultRoute.handle(evt);
                 if (!resp) {
                     throw new Error("Router's defaultRoute.handle() did not return a response.");

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -115,11 +115,9 @@ export class Router {
                     postProcessors.push(route);
                 }
                 if (route.handle) {
+                    handlingRoute = route;
                     try {
                         resp = await route.handle(evt);
-                        if (resp) {
-                            handlingRoute = route;
-                        }
                     } catch (err) {
                         resp = await this.errorToRouterResponse(err, pevt, ctx);
                     }

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -157,7 +157,7 @@ export class Router {
     private proxyEventToRouterEvent(evt: ProxyEvent): RouterEvent {
         const r = new RouterEvent();
 
-        r.context = evt.context;
+        r.requestContext = evt.requestContext;
         r.headers = evt.headers || {};
         r.multiValueHeaders = evt.multiValueHeaders || {};
         r.httpMethod = evt.httpMethod;

--- a/src/RouterEvent.ts
+++ b/src/RouterEvent.ts
@@ -14,20 +14,27 @@ export class RouterEvent {
         accountId: string,
         apiId: string,
         httpMethod: string,
+        authorizer?: {
+            [name: string]: any,
+        },
         identity: {
             accessKey: string,
             apiKey: string,
             accountId: string,
+            apiKeyId: string,
             caller: string,
             cognitoAuthenticationProvider: string,
             cognitoAuthenticationType: string,
+            cognitoIdentityId: string,
             cognitoIdentityPoolId: string,
             sourceIp: string,
             user: string,
             userAgent: string,
             userArn: string
         },
+        path: string,
         requestId: string,
+        requestTimeEpoch: number,
         resourceId: string,
         resourcePath: string,
         stage: string

--- a/src/RouterEvent.ts
+++ b/src/RouterEvent.ts
@@ -10,13 +10,11 @@ export class RouterEvent {
      * API Gateway event context.
      * @link https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format
      */
-    context: {
+    requestContext: {
         accountId: string,
         apiId: string,
+        authorizer?: { [name: string]: any, },
         httpMethod: string,
-        authorizer?: {
-            [name: string]: any,
-        },
         identity: {
             accessKey: string,
             apiKey: string,


### PR DESCRIPTION
Covers two unrelated issues: 
- In the previous release, an array of Routes that participate in event handling was passed to the postProcess function on success only. In this update, handling Routes are now passed through regardless of success or failure in order to more accurately represent the flow that the event passes through. 
- Update `RouterEvent.context` and `ProxyEvent.context` to include all properties of `@types/aws-lambda APIGatewayProxyEvent.requestContext`. See issue #4.